### PR TITLE
Change Wikipedia URL to novel page

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -55,7 +55,7 @@
 		<meta property="se:production-notes">The preface was not included in Project Gutenberg and was transcripted separately. The ToC is changed from the output of print-toc because those sections all have the same titles; therefore they are differentiated in the ToC by their subtitles.</meta>
 		<meta property="se:word-count">84177</meta>
 		<meta property="se:reading-ease.flesch">60.35</meta>
-		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Penguin_Island</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Penguin_Island_(novel)</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/anatole-france_penguin-island_a-w-evans</meta>
 		<dc:creator id="author">Anatole France</dc:creator>
 		<meta property="file-as" refines="#author">France, Anatole</meta>


### PR DESCRIPTION
The current Wikipedia URL is a disambiguation page. It should be the page for the actual novel.